### PR TITLE
Remove: unused section in the sidebar

### DIFF
--- a/frontend/src/components/SideBar/SideBar.tsx
+++ b/frontend/src/components/SideBar/SideBar.tsx
@@ -10,7 +10,7 @@ import {
   IconMessages,
   IconReceipt2,
   IconReceiptRefund,
-  IconSettings,
+  // IconSettings,
   IconShoppingCart,
   IconSwitchHorizontal,
   IconUsers,

--- a/frontend/src/components/SideBar/SideBar.tsx
+++ b/frontend/src/components/SideBar/SideBar.tsx
@@ -34,7 +34,7 @@ const tabs: Record<
     { link: "", label: "Report Activities", icon: IconAlertHexagon },
     { link: "", label: "Check Activities", icon: IconShieldSearch },
     { link: "", label: "Balances", icon: IconReceipt2 },
-    { link: "", label: "Other Settings", icon: IconSettings },
+    // { link: "", label: "Other Settings", icon: IconSettings },
   ],
   general: [
     // To Be Used Later


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on commenting out the `IconSettings` entry in the `tabs` array within the `SideBar.tsx` file, indicating that this feature is no longer needed or is temporarily disabled.

### Detailed summary
- Commented out the `IconSettings` entry in the `tabs` array:
  - Changed from `{ link: "", label: "Other Settings", icon: IconSettings }` to `// { link: "", label: "Other Settings", icon: IconSettings }`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->